### PR TITLE
Fix insert for repeated start, end

### DIFF
--- a/interval/insert.go
+++ b/interval/insert.go
@@ -105,9 +105,9 @@ func insert[V, T any](n *node[V, T], intervl interval[V, T], cmp CmpFunc[T]) *no
 	case intervl.equal(n.interval.start, n.interval.end, cmp):
 		n.interval.vals = append(n.interval.vals, intervl.vals...)
 	case intervl.less(n.interval.start, n.interval.end, cmp):
-		n.left = upsert(n.left, intervl, cmp)
+		n.left = insert(n.left, intervl, cmp)
 	default:
-		n.right = upsert(n.right, intervl, cmp)
+		n.right = insert(n.right, intervl, cmp)
 	}
 
 	if cmp.gt(intervl.end, n.maxEnd) {


### PR DESCRIPTION
If multiple vals are inserted into a MultiValueSearchTree with same start, end intervals, insert() will recurse to upsert() rather than insert(), which causes a wholesale replacement of vals rather than appending as it should, resulting in data loss. This causes insert() to recurse to insert() instead, which does the proper append.