### PR TITLE
MaxEnd: find the interval values that contain the max end of the tree

### DIFF
--- a/interval/search.go
+++ b/interval/search.go
@@ -443,7 +443,7 @@ func (st *MultiValueSearchTree[V, T]) MaxEnd() ([]V, bool) {
 	return vals, true
 }
 
-func maxEnd[V, T any](n *node[V, T], searchEnd T, cmp CmpFunc[T], visit func(n *node[V, T])) {
+func maxEnd[V, T any](n *node[V, T], searchEnd T, cmp CmpFunc[T], visit func(*node[V, T])) {
 
 	// If this node's interval lines up with maxEnd, visit it.
 	if cmp.eq(n.interval.end, searchEnd) {

--- a/interval/search.go
+++ b/interval/search.go
@@ -426,3 +426,37 @@ func (st *MultiValueSearchTree[V, T]) Select(k int) ([]V, bool) {
 
 	return interval.vals, true
 }
+
+// End returns the values in the tree that have the largest ending interval.
+func (st *MultiValueSearchTree[V, T]) MaxEnd() ([]V, bool) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	var vals []V
+	if st.root == nil {
+		return vals, false
+	}
+
+	maxEnd(st.root, st.root.maxEnd, st.cmp, func(n *node[V, T]) {
+		vals = append(vals, n.interval.vals...)
+	})
+	return vals, true
+}
+
+func maxEnd[V, T any](n *node[V, T], searchEnd T, cmp CmpFunc[T], visit func(n *node[V, T])) {
+
+	// If this node's interval lines up with maxEnd, visit it.
+	if cmp.eq(n.interval.end, searchEnd) {
+		visit(n)
+	}
+
+	// Search left if the left subtree contains a max ending interval that is equal to the root's max ending interval.
+	if n.left != nil && cmp.eq(n.left.maxEnd, searchEnd) {
+		maxEnd(n.left, searchEnd, cmp, visit)
+	}
+
+	// Search right if the right subtree contains a max ending interval that is equal to the root's max ending interval.
+	if n.right != nil && cmp.eq(n.right.maxEnd, searchEnd) {
+		maxEnd(n.right, searchEnd, cmp, visit)
+	}
+}

--- a/interval/search.go
+++ b/interval/search.go
@@ -427,7 +427,7 @@ func (st *MultiValueSearchTree[V, T]) Select(k int) ([]V, bool) {
 	return interval.vals, true
 }
 
-// End returns the values in the tree that have the largest ending interval.
+// MaxEnd returns the values in the tree that have the largest ending interval. It returns false as the second return value if the tree is empty; otherwise, true.
 func (st *MultiValueSearchTree[V, T]) MaxEnd() ([]V, bool) {
 	st.mu.Lock()
 	defer st.mu.Unlock()

--- a/interval/search_test.go
+++ b/interval/search_test.go
@@ -3,7 +3,6 @@ package interval
 import (
 	"fmt"
 	"reflect"
-	"slices"
 	"testing"
 	"time"
 )
@@ -999,7 +998,7 @@ func TestMultiValueSearchTree_MaxEnd(t *testing.T) {
 				{start: 20, end: 30, val: "node5"},
 				{start: 25, end: 30, val: "node6"},
 			},
-			expectedMaxEndStrings: []string{"node5", "node6"},
+			expectedMaxEndStrings: []string{"node6", "node5"},
 		},
 		"multiple intervals with same end and same start": {
 			inserts: []insert{
@@ -1007,7 +1006,7 @@ func TestMultiValueSearchTree_MaxEnd(t *testing.T) {
 				{start: 25, end: 30, val: "node6"},
 				{start: 25, end: 30, val: "node7"},
 			},
-			expectedMaxEndStrings: []string{"node5", "node6", "node7"},
+			expectedMaxEndStrings: []string{"node6", "node7", "node5"},
 		},
 		"interval spanning entire range": {
 			inserts: []insert{
@@ -1033,8 +1032,6 @@ func TestMultiValueSearchTree_MaxEnd(t *testing.T) {
 				t.Errorf("st.MaxEnd(): got no max end value")
 			}
 
-			slices.Sort(got)
-			slices.Sort(test.expectedMaxEndStrings)
 			if !reflect.DeepEqual(got, test.expectedMaxEndStrings) {
 				t.Errorf("st.MaxEnd(): got unexpected value %v; want %v", got, test.expectedMaxEndStrings)
 			}


### PR DESCRIPTION
In an attempt to address #7  where I need to find the values that contain the max ending intervals in the tree.

This performs a search on the tree based on the `maxEnd` of the leaves of each sub-tree.