### PR TITLE
fix: CodeCov token not found when running GH action.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,6 @@ jobs:
     - name: Report coverage
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.txt
         fail_ci_if_error: true


### PR DESCRIPTION
Add explicit CodeCov token as a work around to rate-limiting issue like https://github.com/codecov/codecov-action/issues/557