### PR TITLE
fix: update CodeCov to v4.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,9 @@ jobs:
     - name: Test
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
     - name: Report coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.txt
         fail_ci_if_error: true
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
CodeCov upload has been consistently failing when trying to upload coverage for a PR from a fork. This change updates CodeCov to v4 and sets the `CODECOV_TOKEN` env var in an attempt to fix this issue.

See https://github.com/codecov/codecov-action/issues/598