### PR TITLE
interval: add InOrderTraverse() visitor

### DIFF
--- a/interval/search.go
+++ b/interval/search.go
@@ -522,7 +522,7 @@ func (st *SearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
 }
 
 // InOrderTraverse traverses the tree in order and applies VisitFunc to each node. It's safe for concurrent use. To prevent deadlock, avoid calling other tree methods within visitFunc.
-func (tree *MultiValueSearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
+func (st *MultiValueSearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
 	tree.mu.RLock()
 	defer tree.mu.RUnlock()
 

--- a/interval/search.go
+++ b/interval/search.go
@@ -479,8 +479,13 @@ func maxEnd[V, T any](n *node[V, T], searchEnd T, cmp CmpFunc[T], visit func(*no
 	}
 }
 
-// VisitFunc is called on all values. Returning false will stop iteration, so will an error.
-type VisitFunc[V, T any] func(V, T) (bool, error)
+// StopTraversal is used as a return value from [VisitFunc] to indicate that the iteration is to be stopped.
+// It is not returned as an error by any function.
+var StopTraversal = errors.New("stop tree traversal")
+
+// VisitFunc is called on all values. Returning non-nil error will stop iteration.
+// If the returned error is [StopTraversal], the iteration is interrupted, but no error is returned to the caller. 
+type VisitFunc[V, T any] func(V, T) error
 
 // InOrderTraverse traverses the tree in order and applies VisitFunc to each node.
 func (tree *SearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {

--- a/interval/search.go
+++ b/interval/search.go
@@ -526,27 +526,31 @@ func (st *MultiValueSearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T])
 	tree.mu.RLock()
 	defer tree.mu.RUnlock()
 
-	var inOrder func(n *node[V, T]) (bool, error)
-	inOrder = func(n *node[V, T]) (bool, error) {
+	var inOrder func(n *node[V, T]) error
+	inOrder = func(n *node[V, T]) error {
 		if n == nil {
-			return true, nil
+			return nil
 		}
 
 		// Visit left child
-		if ok, err := inOrder(n.Left); !ok || err != nil {
-			return ok, err
+		if err := inOrder(n.Left); err != nil {
+			return err
 		}
 
 		// Visit current node
-		continueTraversal, err := visitFunc(n.Interval.Val, n.Interval.Start)
-		if !continueTraversal || err != nil {
-			return continueTraversal, err
+	        err := visitFunc(n.Interval.Vals, n.Interval.Start)
+		if err != nil {
+			return err
 		}
 
 		// Visit right child
 		return inOrder(n.Right)
 	}
 
-	_, err := inOrder(tree.root)
+	err := inOrder(tree.root)
+	// Do not percolate StopTraversal error to the caller.
+	if errors.Is(err, StopTraversal) {
+	        return nil
+	}
 	return err
 }

--- a/interval/search.go
+++ b/interval/search.go
@@ -521,7 +521,7 @@ func (tree *SearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
 	return err
 }
 
-// InOrderTraverse traverses the tree in order and applies VisitFunc to each node.
+// InOrderTraverse traverses the tree in order and applies VisitFunc to each node. It's safe for concurrent use. To prevent deadlock, avoid calling other tree methods within visitFunc.
 func (tree *MultiValueSearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
 	tree.mu.RLock()
 	defer tree.mu.RUnlock()

--- a/interval/search.go
+++ b/interval/search.go
@@ -487,7 +487,7 @@ var StopTraversal = errors.New("stop tree traversal")
 // If the returned error is [StopTraversal], the iteration is interrupted, but no error is returned to the caller. 
 type VisitFunc[V, T any] func(V, T) error
 
-// InOrderTraverse traverses the tree in order and applies VisitFunc to each node.
+// InOrderTraverse traverses the tree in order and applies VisitFunc to each node. It's safe for concurrent use. To prevent deadlock, avoid calling other tree methods within visitFunc.
 func (tree *SearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
 	tree.mu.RLock()
 	defer tree.mu.RUnlock()

--- a/interval/search.go
+++ b/interval/search.go
@@ -488,7 +488,7 @@ var StopTraversal = errors.New("stop tree traversal")
 type VisitFunc[V, T any] func(V, T) error
 
 // InOrderTraverse traverses the tree in order and applies VisitFunc to each node. It's safe for concurrent use. To prevent deadlock, avoid calling other tree methods within visitFunc.
-func (tree *SearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
+func (st *SearchTree[V, T]) InOrderTraverse(visitFunc VisitFunc[V, T]) error {
 	tree.mu.RLock()
 	defer tree.mu.RUnlock()
 


### PR DESCRIPTION
Add an `InOrderTraverse()` visitor to walk all of the nodes of both the `SearchTree` and `MultiValueSearchTree`.  This is missing public tests, but I don't want to sit on this code.