### PR TITLE
fix performance issue on AllIntersections

### DIFF
--- a/interval/search.go
+++ b/interval/search.go
@@ -94,7 +94,7 @@ func (st *SearchTree[V, T]) AllIntersections(start, end T) ([]V, bool) {
 }
 
 func searchInOrder[V, T any](n *node[V, T], start, end T, cmp CmpFunc[T], foundFn func(interval[V, T])) {
-	if n.Left != nil && cmp.gte(n.Left.MaxEnd, start) {
+	if n.Left != nil && cmp.lte(start, n.Left.MaxEnd) {
 		searchInOrder(n.Left, start, end, cmp, foundFn)
 	}
 
@@ -102,7 +102,7 @@ func searchInOrder[V, T any](n *node[V, T], start, end T, cmp CmpFunc[T], foundF
 		foundFn(n.Interval)
 	}
 
-	if n.Right != nil && cmp.gte(n.Right.MaxEnd, start) {
+	if n.Right != nil && cmp.lte(n.Interval.Start, end) {
 		searchInOrder(n.Right, start, end, cmp, foundFn)
 	}
 }


### PR DESCRIPTION
This commit addresses a performance issue in the AllIntersections function, where the conditional for traversing the right side of the tree was evaluating to true most of the time. This led to unnecessary visits of right nodes, resulting in linear time complexity.

More background on why this fix is correct:

- Left is safe to prune when all lower nodes end before the start of the lookup interval (`Left.MaxEnd < start`). (Note: this case was already correct before this commit, but I reversed the inequality as I find it easier to reason about)
- Right is safe to prune when all higher nodes start after the end of lookup interval (`end < Current.Start`). If the current node starts after the end of the lookup interval, we're guaranteed all its right nodes will also because they all start after the current node by definition.

Fuzz testing yielded consistent results with original implementation. Benchmark showed ~30% speed improvement on average case (random intervals), and over 99.9% improvement in worst case (lookup interval at the far left of the tree). As expected, new implementation explores fewer nodes that can be evicted just as safely in advance.