### PR TITLE
Visit intersections

### DIFF
--- a/interval/delete.go
+++ b/interval/delete.go
@@ -12,7 +12,7 @@ func (st *SearchTree[V, T]) Delete(start, end T) error {
 		return nil
 	}
 
-	intervl := interval[V, T]{
+	intervl := Interval[V, T]{
 		Start:      start,
 		End:        end,
 		AllowPoint: st.config.allowIntervalPoint,
@@ -30,7 +30,7 @@ func (st *SearchTree[V, T]) Delete(start, end T) error {
 	return nil
 }
 
-func delete[V, T any](n *node[V, T], intervl interval[V, T], cmp CmpFunc[T]) *node[V, T] {
+func delete[V, T any](n *node[V, T], intervl Interval[V, T], cmp CmpFunc[T]) *node[V, T] {
 	if n == nil {
 		return nil
 	}
@@ -142,7 +142,7 @@ func (st *MultiValueSearchTree[V, T]) Delete(start, end T) error {
 		return nil
 	}
 
-	intervl := interval[V, T]{
+	intervl := Interval[V, T]{
 		Start:      start,
 		End:        end,
 		AllowPoint: st.config.allowIntervalPoint,

--- a/interval/example_test.go
+++ b/interval/example_test.go
@@ -146,3 +146,38 @@ func ExampleTreeWithIntervalPoint() {
 	// Output:
 	// event true
 }
+
+func ExampleSearchTree_VisitIntersections() {
+	cmpFn := func(x, y int) int { return x - y }
+
+	st := interval.NewSearchTree[string](cmpFn)
+
+	st.Insert(17, 19, "value1")
+	st.Insert(5, 8, "value2")
+	st.Insert(21, 24, "value3")
+	st.Insert(4, 8, "value4")
+	st.Insert(15, 18, "value5")
+	st.Insert(7, 10, "value6")
+
+	fmt.Println("Visiting all intervals that intersect with [9, 16]")
+
+	// Visit all intervals that intersect with [9, 16]
+	st.VisitIntersections(9, 16, func(node interval.Interval[string, int]) {
+		fmt.Println(node.Val)
+	})
+
+	fmt.Println("Visiting all intervals that intersect with [12, 50]")
+
+	// Visit all intervals that intersect with [12, 50]
+	st.VisitIntersections(12, 50, func(node interval.Interval[string, int]) {
+		fmt.Println(node.Val)
+	})
+	// Output:
+	// Visiting all intervals that intersect with [9, 16]
+	// value6
+	// value5
+	// Visiting all intervals that intersect with [12, 50]
+	// value5
+	// value1
+	// value3
+}

--- a/interval/insert.go
+++ b/interval/insert.go
@@ -13,7 +13,7 @@ func (st *SearchTree[V, T]) Insert(start, end T, val V) error {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 
-	intervl := interval[V, T]{
+	intervl := Interval[V, T]{
 		Start:      start,
 		End:        end,
 		Val:        val,
@@ -30,7 +30,7 @@ func (st *SearchTree[V, T]) Insert(start, end T, val V) error {
 	return nil
 }
 
-func upsert[V, T any](n *node[V, T], intervl interval[V, T], cmp CmpFunc[T]) *node[V, T] {
+func upsert[V, T any](n *node[V, T], intervl Interval[V, T], cmp CmpFunc[T]) *node[V, T] {
 	if n == nil {
 		return newNode(intervl, red)
 	}
@@ -61,8 +61,8 @@ func (e EmptyValueListError) Error() string {
 	return string(e)
 }
 
-func newEmptyValueListError[V, T any](it interval[V, T], action string) error {
-	s := fmt.Sprintf("multi value interval search tree: cannot %s empty value list for interval (%v, %v)", action, it.Start, it.End)
+func newEmptyValueListError[V, T any](it Interval[V, T], action string) error {
+	s := fmt.Sprintf("multi value Interval search tree: cannot %s empty value list for Interval (%v, %v)", action, it.Start, it.End)
 	return EmptyValueListError(s)
 }
 
@@ -75,7 +75,7 @@ func newEmptyValueListError[V, T any](it interval[V, T], action string) error {
 func (st *MultiValueSearchTree[V, T]) Insert(start, end T, vals ...V) error {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	intervl := interval[V, T]{
+	intervl := Interval[V, T]{
 		Start:      start,
 		End:        end,
 		Vals:       vals,
@@ -96,7 +96,7 @@ func (st *MultiValueSearchTree[V, T]) Insert(start, end T, vals ...V) error {
 	return nil
 }
 
-func insert[V, T any](n *node[V, T], intervl interval[V, T], cmp CmpFunc[T]) *node[V, T] {
+func insert[V, T any](n *node[V, T], intervl Interval[V, T], cmp CmpFunc[T]) *node[V, T] {
 	if n == nil {
 		return newNode(intervl, red)
 	}
@@ -128,7 +128,7 @@ func insert[V, T any](n *node[V, T], intervl interval[V, T], cmp CmpFunc[T]) *no
 func (st *MultiValueSearchTree[V, T]) Upsert(start, end T, vals ...V) error {
 	st.mu.Lock()
 	defer st.mu.Unlock()
-	intervl := interval[V, T]{
+	intervl := Interval[V, T]{
 		Start:      start,
 		End:        end,
 		Vals:       vals,

--- a/interval/interval.go
+++ b/interval/interval.go
@@ -13,7 +13,7 @@ func (s InvalidIntervalError) Error() string {
 	return string(s)
 }
 
-func newInvalidIntervalError[V, T any](it interval[V, T]) error {
+func newInvalidIntervalError[V, T any](it Interval[V, T]) error {
 	var b strings.Builder
 	fmt.Fprintf(&b, "interval search tree invalid range: start value %v cannot be less than ", it.Start)
 	if !it.AllowPoint {
@@ -52,7 +52,7 @@ func (f CmpFunc[T]) gte(x, y T) bool {
 	return f(x, y) >= 0
 }
 
-type interval[V, T any] struct {
+type Interval[V, T any] struct {
 	Start      T
 	End        T
 	Val        V
@@ -60,21 +60,21 @@ type interval[V, T any] struct {
 	AllowPoint bool
 }
 
-func (it interval[V, T]) isInvalid(cmp CmpFunc[T]) bool {
+func (it Interval[V, T]) isInvalid(cmp CmpFunc[T]) bool {
 	if it.AllowPoint {
 		return cmp.lt(it.End, it.Start)
 	}
 	return cmp.lte(it.End, it.Start)
 }
 
-func (it interval[V, T]) less(start, end T, cmp CmpFunc[T]) bool {
+func (it Interval[V, T]) less(start, end T, cmp CmpFunc[T]) bool {
 	return cmp.lt(it.Start, start) || cmp.eq(it.Start, start) && cmp.lt(it.End, end)
 }
 
-func (it interval[V, T]) intersects(start, end T, cmp CmpFunc[T]) bool {
+func (it Interval[V, T]) intersects(start, end T, cmp CmpFunc[T]) bool {
 	return cmp.lte(it.Start, end) && cmp.lte(start, it.End)
 }
 
-func (it interval[V, T]) equal(start, end T, cmp CmpFunc[T]) bool {
+func (it Interval[V, T]) equal(start, end T, cmp CmpFunc[T]) bool {
 	return cmp.eq(it.Start, start) && cmp.eq(it.End, end)
 }

--- a/interval/node.go
+++ b/interval/node.go
@@ -10,7 +10,7 @@ const (
 )
 
 type node[V, T any] struct {
-	Interval interval[V, T]
+	Interval Interval[V, T]
 	MaxEnd   T
 	Right    *node[V, T]
 	Left     *node[V, T]
@@ -18,7 +18,7 @@ type node[V, T any] struct {
 	Size     int
 }
 
-func newNode[V, T any](intervl interval[V, T], c color) *node[V, T] {
+func newNode[V, T any](intervl Interval[V, T], c color) *node[V, T] {
 	return &node[V, T]{
 		Interval: intervl,
 		MaxEnd:   intervl.End,

--- a/interval/search.go
+++ b/interval/search.go
@@ -17,9 +17,9 @@ func (st *SearchTree[V, T]) Find(start, end T) (V, bool) {
 	return interval.Val, true
 }
 
-func find[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (interval[V, T], bool) {
+func find[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (Interval[V, T], bool) {
 	if root == nil {
-		return interval[V, T]{}, false
+		return Interval[V, T]{}, false
 	}
 
 	cur := root
@@ -34,7 +34,7 @@ func find[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (interval[V,
 		}
 	}
 
-	return interval[V, T]{}, false
+	return Interval[V, T]{}, false
 }
 
 // AnyIntersection returns a value which interval key intersects with the given start and end interval.
@@ -53,9 +53,9 @@ func (st *SearchTree[V, T]) AnyIntersection(start, end T) (V, bool) {
 	return interval.Val, true
 }
 
-func anyIntersections[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (interval[V, T], bool) {
+func anyIntersections[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (Interval[V, T], bool) {
 	if root == nil {
-		return interval[V, T]{}, false
+		return Interval[V, T]{}, false
 	}
 
 	cur := root
@@ -72,7 +72,7 @@ func anyIntersections[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) 
 		cur = next
 	}
 
-	return interval[V, T]{}, false
+	return Interval[V, T]{}, false
 }
 
 // AllIntersections returns a slice of values which interval key intersects with the given start and end interval.
@@ -86,14 +86,14 @@ func (st *SearchTree[V, T]) AllIntersections(start, end T) ([]V, bool) {
 		return vals, false
 	}
 
-	searchInOrder(st.root, start, end, st.cmp, func(it interval[V, T]) {
+	searchInOrder(st.root, start, end, st.cmp, func(it Interval[V, T]) {
 		vals = append(vals, it.Val)
 	})
 
 	return vals, len(vals) > 0
 }
 
-func searchInOrder[V, T any](n *node[V, T], start, end T, cmp CmpFunc[T], foundFn func(interval[V, T])) {
+func searchInOrder[V, T any](n *node[V, T], start, end T, cmp CmpFunc[T], foundFn func(Interval[V, T])) {
 	if n.Left != nil && cmp.lte(start, n.Left.MaxEnd) {
 		searchInOrder(n.Left, start, end, cmp, foundFn)
 	}
@@ -172,9 +172,9 @@ func (st *SearchTree[V, T]) Ceil(start, end T) (V, bool) {
 	return interval.Val, true
 }
 
-func ceil[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (interval[V, T], bool) {
+func ceil[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (Interval[V, T], bool) {
 	if root == nil {
-		return interval[V, T]{}, false
+		return Interval[V, T]{}, false
 	}
 
 	var ceil *node[V, T]
@@ -194,7 +194,7 @@ func ceil[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (interval[V,
 	}
 
 	if ceil == nil {
-		return interval[V, T]{}, false
+		return Interval[V, T]{}, false
 	}
 
 	return ceil.Interval, true
@@ -216,9 +216,9 @@ func (st *SearchTree[V, T]) Floor(start, end T) (V, bool) {
 	return interval.Val, true
 }
 
-func floor[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (interval[V, T], bool) {
+func floor[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (Interval[V, T], bool) {
 	if root == nil {
-		return interval[V, T]{}, false
+		return Interval[V, T]{}, false
 	}
 
 	var floor *node[V, T]
@@ -238,7 +238,7 @@ func floor[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) (interval[V
 	}
 
 	if floor == nil {
-		return interval[V, T]{}, false
+		return Interval[V, T]{}, false
 	}
 
 	return floor.Interval, true
@@ -288,7 +288,7 @@ func (st *SearchTree[V, T]) Select(k int) (V, bool) {
 	return interval.Val, true
 }
 
-func selectInterval[V, T any](root *node[V, T], k int) (interval[V, T], bool) {
+func selectInterval[V, T any](root *node[V, T], k int) (Interval[V, T], bool) {
 	cur := root
 	for cur != nil {
 		t := size(cur.Left)
@@ -303,7 +303,7 @@ func selectInterval[V, T any](root *node[V, T], k int) (interval[V, T], bool) {
 		}
 	}
 
-	return interval[V, T]{}, false
+	return Interval[V, T]{}, false
 }
 
 // Find returns the values which interval key exactly matches with the given start and end interval.
@@ -348,7 +348,7 @@ func (st *MultiValueSearchTree[V, T]) AllIntersections(start, end T) ([]V, bool)
 		return vals, false
 	}
 
-	searchInOrder(st.root, start, end, st.cmp, func(it interval[V, T]) {
+	searchInOrder(st.root, start, end, st.cmp, func(it Interval[V, T]) {
 		vals = append(vals, it.Vals...)
 	})
 

--- a/interval/search.go
+++ b/interval/search.go
@@ -1,7 +1,9 @@
 package interval
 
+type VisitorFunc[V, T any] func(Interval[V, T])
+
 // Find returns the value which interval key exactly matches with the given start and end interval.
-// It returns true as the second return value if an exaclty matching interval key is found in the tree;
+// It returns true as the second return value if an exactly matching interval key is found in the tree;
 // otherwise, false.
 func (st *SearchTree[V, T]) Find(start, end T) (V, bool) {
 	st.mu.RLock()
@@ -75,35 +77,42 @@ func anyIntersections[V, T any](root *node[V, T], start, end T, cmp CmpFunc[T]) 
 	return Interval[V, T]{}, false
 }
 
-// AllIntersections returns a slice of values which interval key intersects with the given start and end interval.
-// It returns true as the second return value if any intersection is found in the tree; otherwise, false.
-func (st *SearchTree[V, T]) AllIntersections(start, end T) ([]V, bool) {
+// VisitIntersections traverses the tree in-order and calls the visitor function for each interval
+// that intersects with the given start and end interval. The visitor function receives the intersecting
+// interval as its argument.
+func (st *SearchTree[V, T]) VisitIntersections(start, end T, visitor VisitorFunc[V, T]) {
 	st.mu.RLock()
 	defer st.mu.RUnlock()
 
-	var vals []V
 	if st.root == nil {
-		return vals, false
+		return
 	}
 
-	searchInOrder(st.root, start, end, st.cmp, func(it Interval[V, T]) {
+	visitInOrder(st.root, start, end, st.cmp, visitor)
+}
+
+// AllIntersections returns a slice of values which Interval key intersects with the given start and end Interval.
+// It returns true as the second return value if any intersection is found in the tree; otherwise, false.
+func (st *SearchTree[V, T]) AllIntersections(start, end T) ([]V, bool) {
+	var vals []V
+	st.VisitIntersections(start, end, func(it Interval[V, T]) {
 		vals = append(vals, it.Val)
 	})
 
 	return vals, len(vals) > 0
 }
 
-func searchInOrder[V, T any](n *node[V, T], start, end T, cmp CmpFunc[T], foundFn func(Interval[V, T])) {
+func visitInOrder[V, T any](n *node[V, T], start, end T, cmp CmpFunc[T], visitor VisitorFunc[V, T]) {
 	if n.Left != nil && cmp.lte(start, n.Left.MaxEnd) {
-		searchInOrder(n.Left, start, end, cmp, foundFn)
+		visitInOrder(n.Left, start, end, cmp, visitor)
 	}
 
 	if n.Interval.intersects(start, end, cmp) {
-		foundFn(n.Interval)
+		visitor(n.Interval)
 	}
 
 	if n.Right != nil && cmp.lte(n.Interval.Start, end) {
-		searchInOrder(n.Right, start, end, cmp, foundFn)
+		visitInOrder(n.Right, start, end, cmp, visitor)
 	}
 }
 
@@ -337,18 +346,25 @@ func (st *MultiValueSearchTree[V, T]) AnyIntersection(start, end T) ([]V, bool) 
 	return interval.Vals, true
 }
 
-// AllIntersections returns a slice of values which interval key intersects with the given start and end interval.
-// It returns true as the second return value if any intersection is found in the tree; otherwise, false.
-func (st *MultiValueSearchTree[V, T]) AllIntersections(start, end T) ([]V, bool) {
+// VisitIntersections traverses the tree in-order and calls the visitor function for each interval
+// that intersects with the given start and end interval. The visitor function receives the intersecting
+// interval as its argument.
+func (st *MultiValueSearchTree[V, T]) VisitIntersections(start, end T, visitor VisitorFunc[V, T]) {
 	st.mu.RLock()
 	defer st.mu.RUnlock()
 
-	var vals []V
 	if st.root == nil {
-		return vals, false
+		return
 	}
 
-	searchInOrder(st.root, start, end, st.cmp, func(it Interval[V, T]) {
+	visitInOrder(st.root, start, end, st.cmp, visitor)
+}
+
+// AllIntersections returns a slice of values which Interval key intersects with the given start and end Interval.
+// It returns true as the second return value if any intersection is found in the tree; otherwise, false.
+func (st *MultiValueSearchTree[V, T]) AllIntersections(start, end T) ([]V, bool) {
+	var vals []V
+	st.VisitIntersections(start, end, func(it Interval[V, T]) {
 		vals = append(vals, it.Vals...)
 	})
 


### PR DESCRIPTION
Allow iterating all the intersections with a visitor function. 
This allows access to the intersecting interval nodes to implement custom logic like 'intersecting interval with the smallest start' or 'top 3 largest values in intersection'.